### PR TITLE
1.1.1

### DIFF
--- a/.github/workflows/maturin_upload_pypi.yml
+++ b/.github/workflows/maturin_upload_pypi.yml
@@ -123,7 +123,7 @@ jobs:
           path: dist
 
   check_clippy_python_bindings:
-    name: Check clippy for C bindings
+    name: Check clippy for Python bindings
     runs-on: ubuntu-latest
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2023-12-23
+
 ### Fixed
 
 - Python bindings:
@@ -59,6 +61,7 @@ version of the library.
 - Initial relase
 
 [unreleased]: https://github.com/Decompollaborate/ipl3checksum/compare/main...develop
+[1.1.1]: https://github.com/Decompollaborate/ipl3checksum/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/Decompollaborate/ipl3checksum/compare/1.0.1...1.1.0
 [1.0.1]: https://github.com/Decompollaborate/ipl3checksum/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/Decompollaborate/ipl3checksum/releases/tag/1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python bindings:
   - Fix `detectCIC` and `detect_cic_raw` functions not accepting `bytearray`
     objects.
+- Fix some typos
 
 ## [1.1.0] - 2023-12-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Python bindings:
+  - Fix `detectCIC` and `detect_cic_raw` functions not accepting `bytearray`
+    objects.
+
 ## [1.1.0] - 2023-12-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
 dependencies = [
  "unicode-ident",
 ]
@@ -203,9 +203,9 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "syn"
-version = "2.0.41"
+version = "2.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
+checksum = "5b7d0a2c048d661a1a59fcd7355baa232f7ed34e0ee4df2eef3c1c1c0d3852d8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "ipl3checksum"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "md5",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "ipl3checksum"
 # Version should be synced with src/ipl3checksum/__init__.py, pyproject.toml and src/rs/version.rs
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 description = "Library to calculate the IPL3 checksum for N64 ROMs"
 repository = "https://github.com/decompollaborate/ipl3checksum"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "ipl3checksum"
 # Version should be synced with src/ipl3checksum/__init__.py, Cargo.toml and src/rs/version.rs
-version = "1.1.0"
+version = "1.1.1.dev0"
 description = "Library to calculate the IPL3 checksum for N64 ROMs"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "ipl3checksum"
 # Version should be synced with src/ipl3checksum/__init__.py, Cargo.toml and src/rs/version.rs
-version = "1.1.1.dev0"
+version = "1.1.1"
 description = "Library to calculate the IPL3 checksum for N64 ROMs"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/ipl3checksum/__init__.py
+++ b/src/ipl3checksum/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 # Version should be synced with pyproject.toml, Cargo.toml and src/rs/version.rs
 __version_info__: tuple[int, int, int] = (1, 1, 1)
-__version__ = ".".join(map(str, __version_info__)) + ".dev0"
+__version__ = ".".join(map(str, __version_info__))
 __author__ = "Decompollaborate"
 
 from .ipl3checksum import *

--- a/src/ipl3checksum/__init__.py
+++ b/src/ipl3checksum/__init__.py
@@ -6,8 +6,8 @@
 from __future__ import annotations
 
 # Version should be synced with pyproject.toml, Cargo.toml and src/rs/version.rs
-__version_info__: tuple[int, int, int] = (1, 1, 0)
-__version__ = ".".join(map(str, __version_info__))
+__version_info__: tuple[int, int, int] = (1, 1, 1)
+__version__ = ".".join(map(str, __version_info__)) + ".dev0"
 __author__ = "Decompollaborate"
 
 from .ipl3checksum import *

--- a/src/rs/detect.rs
+++ b/src/rs/detect.rs
@@ -47,12 +47,20 @@ pub fn detect_cic(rom_bytes: &[u8]) -> Result<CICKind, Ipl3ChecksumError> {
 #[allow(non_snake_case)]
 pub(crate) mod python_bindings {
     use pyo3::prelude::*;
+    use std::borrow::Cow;
+
+    /**
+     * We use a `Cow` instead of a plain &[u8] the latter only allows Python's
+     * `bytes` objects, while Cow allows for both `bytes` and `bytearray`.
+     * This is important because an argument typed as `bytes` allows to pass a
+     * `bytearray` object too.
+     */
 
     #[pyfunction]
     pub(crate) fn detectCICRaw(
-        raw_bytes: &[u8],
+        raw_bytes: Cow<[u8]>,
     ) -> Result<Option<super::CICKind>, super::Ipl3ChecksumError> {
-        match super::detect_cic_raw(raw_bytes) {
+        match super::detect_cic_raw(&raw_bytes) {
             Ok(cic) => Ok(Some(cic)),
             Err(e) => match e {
                 super::Ipl3ChecksumError::BufferSizeIsWrong {
@@ -67,9 +75,9 @@ pub(crate) mod python_bindings {
 
     #[pyfunction]
     pub(crate) fn detectCIC(
-        rom_bytes: &[u8],
+        rom_bytes: Cow<[u8]>,
     ) -> Result<Option<super::CICKind>, super::Ipl3ChecksumError> {
-        match super::detect_cic(rom_bytes) {
+        match super::detect_cic(&rom_bytes) {
             Ok(cic) => Ok(Some(cic)),
             Err(e) => match e {
                 super::Ipl3ChecksumError::BufferSizeIsWrong {

--- a/src/rs/version.rs
+++ b/src/rs/version.rs
@@ -4,12 +4,12 @@
 // Version should be synced with pyproject.toml, Cargo.toml and src/ipl3checksum/__init__.py
 pub static VERSION_MAJOR: i32 = 1;
 pub static VERSION_MINOR: i32 = 1;
-pub static VERSION_PATCH: i32 = 0;
+pub static VERSION_PATCH: i32 = 1;
 
 pub static VERSION_INFO: (i32, i32, i32) = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH);
 
 // TODO: figure out a way to construct this string by using VERSION_MAJOR, VERSION_MINOR and VERSION_PATCH (concat! and stringify! didn't work)
-pub static VERSION_STR: &str = "1.1.0";
+pub static VERSION_STR: &str = "1.1.1";
 
 pub static AUTHOR: &str = "Decompollaborate";
 
@@ -24,7 +24,7 @@ mod c_bindings {
 
     // TODO: construct this from super::VERSION_STR
     #[no_mangle]
-    static ipl3checksum_version_str: &[u8] = b"1.1.0\0";
+    static ipl3checksum_version_str: &[u8] = b"1.1.1\0";
 
     // TODO: construct this from super::AUTHOR
     #[no_mangle]


### PR DESCRIPTION
## [1.1.1] - 2023-12-23

### Fixed

- Python bindings:
  - Fix `detectCIC` and `detect_cic_raw` functions not accepting `bytearray`
    objects.
- Fix some typos
